### PR TITLE
Axiom AxVec_card

### DIFF
--- a/axioms.v
+++ b/axioms.v
@@ -7,7 +7,6 @@ From mathcomp Require Import all_ssreflect.
 Require Import List. Import ListNotations.
 Require Import Reals Rpower.
 Require Import Extraction.
-Require Import Omega.
 
 (** Axioms. Extraction schemes are language specific, and can be
  found in files: 

--- a/axioms.v
+++ b/axioms.v
@@ -7,6 +7,7 @@ From mathcomp Require Import all_ssreflect.
 Require Import List. Import ListNotations.
 Require Import Reals Rpower.
 Require Import Extraction.
+Require Import Omega.
 
 (** Axioms. Extraction schemes are language specific, and can be
  found in files: 
@@ -38,7 +39,13 @@ Definition AxVec_of_list (n:nat) (t:Type) (l:list t) : AxVec (length l) t :=
 Axiom AxVec_finite : forall (n:nat) (t:finType), Finite.class_of (AxVec n t).
 Definition AxVec_finType (n:nat) (t:finType) : finType :=
   Finite.Pack (AxVec_finite n t) (AxVec n t).
-Axiom AxVec_card : forall m n (t:finType), #|t| = 2^n -> #|AxVec_finType m t| = 2^(m*n).
+Axiom AxVec_card_gen : forall a b (t:finType), #|t| = a -> #|AxVec_finType b t| = a ^ b.
+Lemma AxVec_card : forall m n (t:finType), #|t| = 2^n -> #|AxVec_finType m t| = 2^(m*n).
+  intros. rewrite (@AxVec_card_gen (2 ^ n) m).
+  - rewrite <- mult_comm. rewrite Nat.pow_mul_r. reflexivity. 
+  - assumption.
+  Qed.
+
 
 (*Axiom AxVec_map : forall (n:nat) (s t:Type), (s -> t) -> AxVec n s -> AxVec n t.
 Axiom AxVec_cons: forall (n:nat) (t:Type), t -> AxVec n t -> AxVec (S n) t.


### PR DESCRIPTION
In order to prove the generalization bounds for the budget kernel perceptron, I needed a more general version of the AxVec_card axiom. Using this axiom, I was able to prove AxVec_card. I made no other changes to AxVec_card. Please pull these changes to make sure this did not break any proofs elsewhere. Thank you!