### PR TITLE
Budget Kernel Perceptron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@
 *.cmi
 *.cmx
 *.o
+hs/*.hi
+hs/PerceptronTest
+hs/Perceptron.hs
+hs/KPerceptronTest
+hs/KPerceptron.hs
+hs/KPerceptronBudgetTest
+hs/KPerceptronBudget.hs

--- a/axioms.v
+++ b/axioms.v
@@ -54,7 +54,7 @@ Definition AxVec_map (n:nat) (s t:Type) : (s -> t) -> AxVec n s -> AxVec n t:=
   fun f a => Vector.map f a.
 Definition AxVec_cons (n:nat) (t:Type) : t -> AxVec n t -> AxVec (S n) t := 
   fun t' a => cons t t' n a.
-Definition AxVec_tail (n:nat) (t:Type) : AxVec (S n) t -> AxVec n t := 
+Definition AxVec_init (n:nat) (t:Type) : AxVec (S n) t -> AxVec n t := 
   fun a => Vector.shiftout a.
 
 Definition AxMat A n m := AxVec n (AxVec m A).

--- a/extraction_hs.v
+++ b/extraction_hs.v
@@ -27,7 +27,7 @@ Extract Constant AxVec_to_list => "(\_ l -> l)".
 
 Extract Constant AxVec_map => "GHC.Base.const GHC.Base.fmap".
 Extract Constant AxVec_cons => "(\_ ->  (:))".
-Extract Constant AxVec_tail => "(\_ a -> Prelude.init a)".
+Extract Constant AxVec_init => "(\_ a -> Prelude.init a)".
 
 (*(*AxVec Tests*)*)
 (* Require Import List. *)

--- a/extraction_hs.v
+++ b/extraction_hs.v
@@ -27,7 +27,7 @@ Extract Constant AxVec_to_list => "(\_ l -> l)".
 
 Extract Constant AxVec_map => "GHC.Base.const GHC.Base.fmap".
 Extract Constant AxVec_cons => "(\_ ->  (:))".
-Extract Constant AxVec_init => "(\_ a -> Prelude.init a)".
+Extract Constant AxVec_init => "(\_ -> Prelude.init)".
 
 (*(*AxVec Tests*)*)
 (* Require Import List. *)

--- a/extraction_hs.v
+++ b/extraction_hs.v
@@ -25,7 +25,9 @@ Extract Constant AxVec "t" => "[t]".
   Coq lists to Haskell lists (see the 'Extract Inductive list' directive above).*)
 Extract Constant AxVec_to_list => "(\_ l -> l)".
 
-Extract Constant AxVec_map => "const fmap".
+Extract Constant AxVec_map => "GHC.Base.const GHC.Base.fmap".
+Extract Constant AxVec_cons => "(\_ a b -> [a] Prelude.++ b)".
+Extract Constant AxVec_tail => "(\_ a -> Prelude.init a)".
 
 (*(*AxVec Tests*)*)
 (* Require Import List. *)

--- a/extraction_hs.v
+++ b/extraction_hs.v
@@ -26,7 +26,7 @@ Extract Constant AxVec "t" => "[t]".
 Extract Constant AxVec_to_list => "(\_ l -> l)".
 
 Extract Constant AxVec_map => "GHC.Base.const GHC.Base.fmap".
-Extract Constant AxVec_cons => "(\_ a b -> [a] Prelude.++ b)".
+Extract Constant AxVec_cons => "(\_ ->  (:))".
 Extract Constant AxVec_tail => "(\_ a -> Prelude.init a)".
 
 (*(*AxVec Tests*)*)

--- a/hs/KPerceptronBudgetTest.hs
+++ b/hs/KPerceptronBudgetTest.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE StandaloneDeriving #-}
---must compile with flag -XTypeSynonymInstances
+{-# LANGUAGE TypeSynonymInstances #-}
 
 module Main where
 

--- a/hs/KPerceptronBudgetTest.hs
+++ b/hs/KPerceptronBudgetTest.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Main where
+
+import System.Random
+
+import KPerceptronBudget
+
+fromInt 0 = O
+fromInt n | n > 0 = S (fromInt $ n - 1)
+
+fromNat O = 0
+fromNat (S n) = 1 + fromNat n
+
+n = fromInt 3 --the number of dimensions
+m = fromInt 200 --the number of samples
+sv = fromInt 20 --the number of support vectors
+epochs = fromInt 5
+
+dist _ = -1.0 --not used in sampler below
+
+--init_weights :: Float32_arr
+--init_weights = take (fromNat m) $ repeat 0.0
+
+--makeKernelParams :: [(Ak, Bk)] -> Params [(Ak, Bk)]
+--makeKernelParams dataset = (dataset, init_weights)
+
+makeBudgetParams :: [((Ordinal, Float32_arr), Bk)] -> Params
+makeBudgetParams dataset = []
+
+{-makeFoldable :: KPerceptronBudget.Foldable Bsupport_vectors (Float32, Bsupport_vector)
+makeFoldable = KPerceptronBudget.MkFoldable (() -> (Monad Any) -> () -> ((Float32, Bsupport_vector) -> Any -> Any) -> Any -> Bsupport_vectors ->
+Any) (() -> (Monad Any) -> ((Float32,Bsupport_vector) -> Any) -> Bsupport_vectors -> Any)-}
+
+categorize :: Nat -> (,) Float32_arr Float32 -> [Float32] -> Bk
+categorize n p a =
+  case p of {
+   (,) w b -> f32_gt (f32_add (f32_dot n w a) b) f32_0}
+
+print_training_set [] = return ()
+print_training_set (((i,xs),y) : t) =
+  let print_xs [] = return ()
+      print_xs (x : xs) = putStr (show x) >> putStr "," >> print_xs xs
+  in
+  do { putStrLn (show $ fromNat i)
+     ; print_xs xs
+     ; putStrLn (show y)
+     ; print_training_set t }
+
+kernel_predict_specialized ::
+  Params ->
+  Ak ->
+  Bk
+kernel_predict_specialized kparams ak =
+  kernel_predict_budget n m sv (KPerceptronBudget.linear_kernel n) list_Foldable kparams ak
+       
+sampler hyperplane _ f =
+  do { t <- training_set hyperplane n m
+     ; putStrLn "Training Set:"
+     ; print_training_set t
+     ; f t }
+
+training_example O = return []
+training_example (S n) =
+  do { r <- randomRIO (-1.0,1.0)
+     ; e <- training_example n
+     ; return $ r : e }
+training_row hyperplane i n = 
+  do { example <- training_example n
+     ; let label = categorize n (hyperplane, 0.0) example
+     ; return ((i, example), label) }
+  where int2bool :: Int -> Bool
+        int2bool 0 = False
+        int2bool 1 = True
+
+training_set _ _ O = return []
+training_set hyperplane n (S m)
+  = do { r <- training_row hyperplane m n
+       ; t <- training_set hyperplane n m
+       ; return $ r : t }
+
+test_set = training_set
+
+print_generalization_err ::
+  [(Ak, Bk)] ->
+  Params ->
+  IO ()
+print_generalization_err test (model, training) =
+  let (train, params) = model in
+  let corrects dataset = 
+        map (\(example, label) ->
+                if kernel_predict_specialized model example == label
+                then 1 :: Int
+                else 0) dataset
+      percent_correct_training
+        = fromIntegral (sum $ corrects train) / fromIntegral (fromNat m)
+      percent_correct_test
+        = fromIntegral (sum $ corrects test) / fromIntegral (fromNat m)
+  in putStrLn
+     $ "Model: " ++ show params ++ "\n"
+       ++ "Training: " ++ show percent_correct_training ++ "\n"
+       ++ "Test: " ++ show percent_correct_test ++ "\n"
+       ++ "Generalization Error: "
+       ++ show (abs (percent_correct_training - percent_correct_test))
+     
+main = 
+  do { hyperplane <- training_example n
+     ; test <- test_set hyperplane n m
+     ; kperceptronbudget n m sv epochs (KPerceptronBudget.linear_kernel n) (budget_update n m sv list_Foldable) list_Foldable (sampler hyperplane) dist
+     makeBudgetParams (print_generalization_err test) }
+         

--- a/kernelperceptron.v
+++ b/kernelperceptron.v
@@ -8,7 +8,7 @@ Require Import NArith.
 Require Import List. Import ListNotations.
 Require Import Extraction.
 
-Require Import MLCert.float32 MLCert.learners MLCert.extraction_hs MLCert.monads.
+Require Import MLCert.axioms MLCert.float32 MLCert.learners MLCert.extraction_hs MLCert.monads.
 
 Section KernelClassifier.
   Variable n : nat. (*the dimensionality*)
@@ -18,6 +18,7 @@ Section KernelClassifier.
   Definition Bk := bool. (*labels*)
   Context {support_vectors} `{Foldable support_vectors ('I_m * float32_arr n * bool)}.
   Definition KernelParams := (support_vectors * float32_arr m)%type.
+  Check support_vectors.
 
   Section predict.
     Open Scope f32_scope.
@@ -44,25 +45,32 @@ Section KernelClassifierBudget.
   Variable m : nat. (*#examples*)
   
   Variable sv : nat. (*#support vectors*)
-
-  Definition Akb := ('I_m * float32_arr n)%type. (*examples*)
+  Variable K: float32_arr n -> float32_arr n -> float32.
+  
+  (*Old way of defining A, B, and support vectors
+  Definition Akb: Type := ('I_m * float32_arr n). (*examples*)
   Definition Bkb := bool. (*labels*)
-  Context {support_vectors} `{Foldable support_vectors ('I_sv * float32_arr n * bool)}.
-  Definition KernelParamsBudget := (float32 *support_vectors * float32_arr sv)%type.
 
+  Definition bsupport_vector: Type := Akb * Bkb.
+  Definition bsupport_vectors: Type := AxVec_finType sv (float32 * bsupport_vector).*)
+  Definition Akb : Type := [finType of 'I_m * float32_arr_finType n].
+  Definition Bkb := bool_finType.
+  Definition bsupport_vector : finType := [finType of Akb * Bkb].
+  Definition bsupport_vectors : finType := AxVec_finType sv [finType of float32_finType * bsupport_vector].
+  Context `{Foldable bsupport_vectors (float32 * bsupport_vector)}.
+  
   Section predict.
     Open Scope f32_scope.
 
-    Definition kernel_predict_budget (K : float32_arr n -> float32_arr n -> float32) 
-        (w : KernelParamsBudget) (x : Akb) : Bkb :=
-      let (u, T) := w.1 in 
+    Definition kernel_predict_budget
+               (w: bsupport_vectors)
+               (x: Akb) : Bkb :=
       foldable_foldM
-        (fun xi_yi r =>
-           let: ((i, xi), yi) := xi_yi in
-           let: (j, xj) := x in 
-           let: wi := f32_get i w.2 in 
-           r + (float32_of_bool yi) * wi * (K xi xj))
-        0 T > 0.
+        (fun wi_xi r =>
+           let: (_, x) := x in
+           let: (wi, ((_, xi), yi)) := wi_xi in 
+           r + (float32_of_bool yi) * wi * (K xi x))
+        0 w > 0.
   End predict.
 End KernelClassifierBudget.
 
@@ -100,13 +108,13 @@ Module KernelPerceptronBudget.
   Section Learner.
     Variable n : nat. (*the dimensionality*)
     Variable m : nat. (*#examples*)
-    Variable sv : nat. (*#support vectors*)
+    Variable sv : nat. (*#support vectors - 1*)
     Notation A := (Ak n m).
     Notation B := Bk.
-    Context {support_vectors} `{F:Foldable support_vectors ('I_sv * float32_arr n * B)}.        
-    Definition Params := @KernelParamsBudget sv support_vectors.
+    Definition Params := bsupport_vectors n m (S sv).
+    Context `{F: Foldable (bsupport_vectors n m (S sv)) (float32 * bsupport_vector n m)}.   
     Variable K : float32_arr n -> float32_arr n -> float32.
-    Variable U : Params -> float32_arr n -> Params. 
+    Variable U : Params -> A*B -> Params. 
     
     Record Hypers : Type := mkHypers { }.
 
@@ -121,53 +129,32 @@ Module KernelPerceptronBudget.
       | O => f32_0
       | S x' => (nat_to_f32 x') + f32_1
       end.
-    
-    (*Definition of existing that doesn't work*)
-    (*Definition existing (s : support_vectors) (e : float32_arr n) : nat :=
+
+    (*Is x in s?*)
+    Set Printing All.
+    Definition existing (s : Params) (yj : A) : bool :=
+      let: (j, y) := yj in 
       foldable_foldM
-        (fun x r =>
-          let: ((i, xi), l) := x in
-          let: y := f32_arr_eq xi e in
-          if y then i else r)
-          (S sv) s.*)
-    
-    Definition existing (s : support_vectors) (e : float32_arr n) : nat :=
-       O.
+        (fun wi_xi r =>
+           let: (_, ((i, x), l)) := wi_xi
+           in (i == j) || r)
+        false s.
        
-    Definition upd_weights  
-      (w : float32_arr sv) (s t : float32) : float32_arr sv :=       
-      if f32_eq t f32_0
-        then f32_upd_f32 s f32_0 w
-        else f32_upd_f32 s (f32_get_f32 s w + 1) w.
-      
-    (*Definition of replace that doesn't work *)
-    (*Definition replace (s : support_vectors) (e : float32_arr n)
-        (t : float32) : support_vectors :=
-    foldable_mapM 
-      (fun x => 
-        let: ((i, x'),y) := x in
-        if f32_eq (nat_to_f32 i) t 
-          then ((i, e),y)
-          else ((i, x'),y))
-       s.*)
+    Definition upd_weights (p: Params) (yj: A): Params :=
+      let: (j, y) := yj in 
+      AxVec_map
+        (fun xi =>
+           let: (wi, ((i, x), li)) := xi in 
+           if i == j then (wi+1, ((i, x), li))
+           else xi)
+        p.
+
+    Definition add_new (p: Params) (yj: A*B): Params :=
+      AxVec_cons (1, yj) (AxVec_tail p).
     
-    Definition replace (s : support_vectors) (e : float32_arr n)
-        (t : float32) : support_vectors := s.
-    
-    Definition index_update (i : float32) : float32 :=
-      if f32_eq (i + f32_1) (nat_to_f32 sv) 
-        then f32_0 else i + f32_1. 
-   
-    Definition budget_update (p : Params) (e : float32_arr n) : Params :=
-      let: (supports_index, weights) := p in
-      let: (index, supports) := supports_index in
-      let: t := existing supports e in
-      if t < (S sv) 
-        then (* increment existing support vector's weight*)
-        ((index,supports), upd_weights weights (nat_to_f32 t) f32_1)
-        else (* replace support vector at index with e*)
-        ((index_update index, replace supports e index), 
-           upd_weights weights index f32_0).
+    Definition budget_update (p: Params) (yj: A*B): Params :=
+      if existing p yj.1 then upd_weights p yj.1
+      else add_new p yj.
       
     Definition kernel_update 
       (K : float32_arr n -> float32_arr n -> float32)
@@ -175,11 +162,11 @@ Module KernelPerceptronBudget.
       let: ((i, example), label) := example_label in 
       let: predicted_label := kernel_predict_budget K p (i, example) in
       if Bool.eqb predicted_label label then p
-      else (U p example).
+      else (U p example_label).
 
     Definition Learner : Learner.t A B Hypers Params :=
       Learner.mk
-        (fun _ => @kernel_predict_budget n m sv support_vectors F K)
+        (fun _ => @kernel_predict_budget n m (S sv) K F)
         (kernel_update K).
   End Learner.
 End KernelPerceptronBudget.
@@ -205,13 +192,13 @@ Section KernelPerceptronGeneralization.
   Variable K : float32_arr n -> float32_arr n -> float32.
 
   (*Represent the training set as a one-dimensional (flattened) float array.*)
-  Definition support_vectors := float32_arr_finType (m*n).
-  Context {H: Foldable support_vectors (A * B)}.
-
-  Notation Params := [finType of {:support_vectors * float32_arr_finType m}].
+  Definition KPsupport_vectors := float32_arr_finType (m*n).
+  Context {H: Foldable KPsupport_vectors (A * B)}.
+  
+  Notation Params := [finType of {:KPsupport_vectors * float32_arr_finType m}].
   Definition Kaccuracy := 
     @accuracy01 A _ m Params (Learner.predict 
-      (@KernelPerceptron.Learner n m support_vectors H K) hypers).
+      (@KernelPerceptron.Learner n m KPsupport_vectors H K) hypers).
 
   Lemma Kcard_Params : INR #|Params| = 2 ^ (m*n*32 + m*32).
   Proof.
@@ -226,7 +213,7 @@ Section KernelPerceptronGeneralization.
 
   Lemma Kperceptron_bound eps (eps_gt0 : 0 < eps) init : 
     @main A B Params KernelPerceptron.Hypers 
-      (@KernelPerceptron.Learner n m support_vectors H K)
+      (@KernelPerceptron.Learner n m KPsupport_vectors H K)
       hypers m m_gt0 epochs d eps init (fun _ => 1) <=
     2^(m*n*32 + m*32) * exp (-2%R * eps^2 * mR m).
   Proof.
@@ -253,28 +240,26 @@ Section KernelPerceptronGeneralizationBudget.
   Variable hypers : KernelPerceptronBudget.Hypers.
   Variable K : float32_arr n -> float32_arr n -> float32.
 
-  (*Represent the training set as a one-dimensional (flattened) float array.*)
-  Definition support_vectors_budget := float32_arr_finType (sv*n).
-  Context {H: Foldable support_vectors_budget ('I_sv * float32_arr n * B)}.
-
-  Notation Params := [finType of {:float32_finType * support_vectors_budget * float32_arr_finType sv}].
-  Variable U : Params -> float32_arr n -> Params.
+  Notation Params := (bsupport_vectors n m (S sv)).
+  Context `{F : Foldable Params (float32 * bsupport_vector n m)}.  
+  Variable U : bsupport_vectors n m (S sv) -> A * B -> bsupport_vectors n m (S sv).
   Definition KaccuracyBudget := 
     @accuracy01 A _ m Params (Learner.predict 
-      (@KernelPerceptronBudget.Learner n m sv support_vectors_budget H K U) hypers).
+      (@KernelPerceptronBudget.Learner n m sv F K U) hypers).
 
   Lemma Kcard_Params_Budget : INR #|Params| = 2 ^ ((32) + (sv*n*32) + (sv*32)).
   Proof.
-    rewrite card_prod !float32_arr_card.
-    rewrite /training_set card_prod !float32_arr_card.
+    unfold Params. 
+    (*(*rewrite !float32_arr_card.*)
+    rewrite /training_set. card_prod !float32_arr_card.
     rewrite float32_card.
     rewrite mult_INR !pow_INR.
     rewrite mult_INR !pow_INR.
     rewrite pow_add.
     rewrite pow_add.
     reflexivity.
-    (*rewrite mult_INR !pow_INR /= pow_add //.*)
-  Qed.
+    (*rewrite mult_INR !pow_INR /= pow_add //.*)*)
+    Admitted.
 
   Variables 
     (not_perfectly_learnable : 
@@ -283,7 +268,7 @@ Section KernelPerceptronGeneralizationBudget.
 
   Lemma Kperceptron_bound_budget eps (eps_gt0 : 0 < eps) init : 
     @main A B Params KernelPerceptronBudget.Hypers 
-      (@KernelPerceptronBudget.Learner n m sv support_vectors_budget H K U)
+      (@KernelPerceptronBudget.Learner n m sv F K U)
       hypers m m_gt0 epochs d eps init (fun _ => 1) <=
     2^((32) + (sv*n*32) + (sv*32)) * exp (-2%R * eps^2 * mR m).
   Proof.

--- a/kernelperceptron.v
+++ b/kernelperceptron.v
@@ -106,7 +106,7 @@ Module KernelPerceptronBudget.
     Notation A := (Ak n m).
     Notation B := Bk.
     Definition Params := bsupport_vectors n m (S sv).
-    Context `{F: Foldable (bsupport_vectors n m (S sv)) (float32 * bsupport_vector n m)}.   
+    Context `{F: Foldable Params (float32 * bsupport_vector n m)}.   
     Variable K : float32_arr n -> float32_arr n -> float32.
     Variable U : Params -> A*B -> Params. 
     

--- a/kernelperceptron.v
+++ b/kernelperceptron.v
@@ -139,7 +139,8 @@ Module KernelPerceptronBudget.
           if f32_arr_eq x yj then (wi+1, (x, li))
           else xi)
         p.
-        
+      
+    (*This function requires that the Params be initialized with (S sv) support vectors*)  
     Definition add_new (p: Params) (yj: A*B): Params :=
       AxVec_cons (1, yj) (AxVec_init p).
     

--- a/kernelperceptron.v
+++ b/kernelperceptron.v
@@ -141,7 +141,7 @@ Module KernelPerceptronBudget.
         p.
         
     Definition add_new (p: Params) (yj: A*B): Params :=
-      AxVec_cons (1, yj) (AxVec_tail p).
+      AxVec_cons (1, yj) (AxVec_init p).
     
     Definition budget_update (p: Params) (yj: A*B): Params :=
       if existing p yj then upd_weights p yj.1

--- a/kernelperceptron.v
+++ b/kernelperceptron.v
@@ -241,8 +241,8 @@ Section KernelPerceptronGeneralizationBudget.
     @accuracy01 A _ m Params (Learner.predict 
       (@KernelPerceptronBudget.Learner n sv F K U) hypers).
 
-  Lemma Kcard_Params_Budget : INR #|Params| =
-    INR ((2 ^ 32) * ((2 ^ (n * 32)) * 2)) ^ (S (sv)).
+  Lemma Kcard_Params_Budget_size : INR #|Params| =
+    INR (((2 ^ 32) * ((2 ^ (n * 32)) * 2)) ^ (S (sv))).    
     
   Proof.
     unfold Params. unfold bsupport_vector. unfold Akb.
@@ -252,6 +252,28 @@ Section KernelPerceptronGeneralizationBudget.
     rewrite card_prod.
     rewrite float32_arr_card. rewrite card_bool. auto.
     Qed.
+    
+  Require Import Omega.
+  Lemma Kcard_Params_Budget_helper : INR (((2 ^ 32) * ((2 ^ (n * 32)) * 2)) ^ (S (sv)))
+  = INR 2^((32*(S sv) + ((1 + n * 32)*(S sv)))).
+  Proof.
+  assert (H: muln (Nat.pow 2 (muln n 32)) 2 = muln 2 (Nat.pow 2 (muln n 32))%coq_nat).
+    { rewrite <- multE. omega. } 
+  rewrite ->  H. 
+  assert (J: muln 2 (Nat.pow 2 (muln n 32)) = Nat.pow 2 (1 + (muln n 32))).
+    { rewrite Nat.pow_succ_r'. auto. }
+  rewrite -> J.
+  rewrite <- Nat.pow_add_r. rewrite <- Nat.pow_mul_r.
+  rewrite pow_INR. rewrite Nat.mul_add_distr_r. auto.
+  Qed.
+  
+  Lemma Kcard_Params_Budget : INR #| Params | = 
+      INR 2^((32*(S sv) + ((1 + n * 32)*(S sv)))).
+  Proof.
+  rewrite Kcard_Params_Budget_size.
+  rewrite Kcard_Params_Budget_helper.
+  auto.
+  Qed.
 
   Variables 
     (not_perfectly_learnable : 
@@ -262,7 +284,7 @@ Section KernelPerceptronGeneralizationBudget.
     @main A B Params KernelPerceptronBudget.Hypers 
       (@KernelPerceptronBudget.Learner n sv F K U)
       hypers m m_gt0 epochs d eps init (fun _ => 1) <=
-    INR ((2 ^ 32) * ((2 ^ (n * 32)) * 2)) ^ (S (sv)) * exp (-2%R * eps^2 * mR m).
+    INR 2^((32*(S sv) + ((1 + n * 32)*(S sv)))) * exp (-2%R * eps^2 * mR m).
   Proof.
     rewrite -Kcard_Params_Budget.
     apply: Rle_trans; first by apply: main_bound.


### PR DESCRIPTION
I believe I have finished the Haskell driver for the Budget Kernel Perceptron. To run the Budget Kernel Perceptron, run `make` in the root directory then `ghc KPerceptronBudgetTest.hs -XTypeSynonymnInstances` to create the executable. I had to add the compile flag to create a Show instance for Ordinals. 

I also updated the .gitignore for the hs/ directory so all Haskell object files and executables are ignored.

Please let me know of any issues. 